### PR TITLE
space-validator and tab-validator reports error at valid empty indented line

### DIFF
--- a/src/validation/space/space-validator.js
+++ b/src/validation/space/space-validator.js
@@ -9,7 +9,7 @@ const validate = (line, lineNumber, editorconfig) => {
 			}
 		}
 
-		if (!line.match(/^ *[^\s]+/)) {
+		if (!line.match(/^ *[\S\r\n]+/)) {
 			return `${lineNumber}: Mixed indentation (only spaces expected)`;
 		}
 	}

--- a/src/validation/space/space-validator.test.js
+++ b/src/validation/space/space-validator.test.js
@@ -22,6 +22,39 @@ test('should return true if line is empty', () => {
 	expect(validate(line, lineNumber, editorconfig)).toEqual('');
 });
 
+test('should return true if line is empty but keep indent with lf', () => {
+	const line = '    \n';
+	const lineNumber = 1;
+	const editorconfig = {
+		indent_style: 'space', // eslint-disable-line camelcase
+		indent_size: 4 // eslint-disable-line camelcase
+	};
+
+	expect(validate(line, lineNumber, editorconfig)).toEqual('');
+});
+
+test('should return true if line is empty but keep indent with cr', () => {
+	const line = '    \r';
+	const lineNumber = 1;
+	const editorconfig = {
+		indent_style: 'space', // eslint-disable-line camelcase
+		indent_size: 4 // eslint-disable-line camelcase
+	};
+
+	expect(validate(line, lineNumber, editorconfig)).toEqual('');
+});
+
+test('should return true if line is empty but keep indent with crlf', () => {
+	const line = '    \r\n';
+	const lineNumber = 1;
+	const editorconfig = {
+		indent_style: 'space', // eslint-disable-line camelcase
+		indent_size: 4 // eslint-disable-line camelcase
+	};
+
+	expect(validate(line, lineNumber, editorconfig)).toEqual('');
+});
+
 test('should return true if text starts directly no matter of indent_style', () => {
 	const line = 'Hello';
 	const lineNumber = 1;

--- a/src/validation/tab/tab-validator.js
+++ b/src/validation/tab/tab-validator.js
@@ -2,7 +2,7 @@ const validate = (line, lineNumber, editorconfig) => {
 	if (line.length > 0 && editorconfig.indent_style === 'tab') {
 		// Starts with tab character * (none, one or more)
 		// and everything but whitespace or space and * (block comment)
-		if (!line.match(/^\t*([^\s]+| \*)/)) {
+		if (!line.match(/^\t*([\S\r\n]+| \*)/)) {
 			return `${lineNumber}: Mixed indentation (only tabs expected)`;
 		}
 	}

--- a/src/validation/tab/tab-validator.test.js
+++ b/src/validation/tab/tab-validator.test.js
@@ -50,6 +50,35 @@ test('should return true if line is empty', () => {
 	expect(validate(line, lineNumber, editorconfig)).toEqual('');
 });
 
+test('should return true if line is empty but keep indent with lf', () => {
+	const line = '\t\n';
+	const lineNumber = 1;
+	const editorconfig = {
+		indent_style: 'tab' // eslint-disable-line camelcase
+	};
+
+	expect(validate(line, lineNumber, editorconfig)).toEqual('');
+});
+
+test('should return true if line is empty but keep indent with cr', () => {
+	const line = '\t\r';
+	const lineNumber = 1;
+	const editorconfig = {
+		indent_style: 'tab' // eslint-disable-line camelcase
+	};
+
+	expect(validate(line, lineNumber, editorconfig)).toEqual('');
+});
+
+test('should return true if line is empty but keep indent with crlf', () => {
+	const line = '\t\r\n';
+	const lineNumber = 1;
+	const editorconfig = {
+		indent_style: 'tab' // eslint-disable-line camelcase
+	};
+
+	expect(validate(line, lineNumber, editorconfig)).toEqual('');
+});
 test('should return false if mixed indentation', () => {
 	const line = '	  	Hello';
 	const lineNumber = 1;


### PR DESCRIPTION

```bash
% ls -al
total 8
drwxrwxr-x. 2 vagrant vagrant  80 Jun  7 10:29 .
drwxrwxrwt. 4 root    root     80 Jun  7 10:28 ..
-rw-rw-r--. 1 vagrant vagrant  55 Jun  7 10:29 .editorconfig
-rw-rw-r--. 1 vagrant vagrant 115 Jun  7 10:29 example.yml
```

`.editorconfig` is

```ini
root = true

[*]
indent_style = space
charset = utf-8
```

`example.yml` is

```yaml
- name: e.g.
  example: |
    next line is empty, but kept indent
    
    this is third line in "example"'s value
```



## expect

```
sucessfully checked 2 files :)
```

## Actual

```
1) ./example.yml
        4: Mixed indentation (only spaces expected)

1 errors occured! See log above and fix errors
```