### PR TITLE
Add `funding` key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   "repository": "https://github.com/editorconfig-checker/editorconfig-checker.javascript",
   "license": "MIT",
   "author": "Max Strübing <mxstrbng@gmail.com> (https://github.com/mstruebing) (https://twitter.com/mxstrbng)",
+  "funding": {
+    "type": "buymeacoffee",
+    "url": "https://www.buymeacoffee.com/mstruebing"
+  },
   "bin": {
     "ec": "./dist/index.js",
     "editorconfig-checker": "./dist/index.js"


### PR DESCRIPTION
Hi! I'm submitting this PR because in the [simple-icons](https://github.com/simple-icons/simple-icons) project we are trying to automate as much as possible our monetary contributions to our direct dependencies, so having this metadata in the package.json files allows us to programmatically know easily how we can fund them. See [package-json#funding](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#funding).

Cheers!