### PR TITLE
Remove duplicate v from core release name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ async function main() {
   if (!(await isReady())) {
     try {
       const [name, assets] = await findRelease(VERSION)
-      console.info(`Downloading v${name}`)
+      console.info(`Downloading ${name}`)
       await downloadBinary(assets.browser_download_url)
     } catch (e) {
       console.error(`Failed to download binary:\n${e}`)


### PR DESCRIPTION
<!-- Please first discuss the change you wish to make via issue before making a change. It might avoid a waste of your time. -->

# What changes this PR introduce?

As of [v3.0.0](https://github.com/editorconfig-checker/editorconfig-checker/releases/tag/v3.0.0), the core release tags have a leading `v`. So, do not print the duplicate `v` in the log message when downloading the binary.

## List any relevant issue numbers

n/a

## Is there anything you'd like reviewers to focus on?

n/a
