### PR TITLE
chore!: rename `ec` to `editorconfig-checker`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ npm start
 
 ## Usage
 
-There is an alias from `editorconfig-checker` to `ec` so you can exchange every occurrence of `editorconfig-checker` with `ec`.
-
 If you installed it via npm you have a binary in your `node_modules/.bin` folder called `editorconfig-checker`.
 Then you could create a script in your `package.json` like this:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "bin": {
-        "ec": "dist/index.js",
         "editorconfig-checker": "dist/index.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "url": "https://www.buymeacoffee.com/mstruebing"
   },
   "bin": {
-    "ec": "./dist/index.js",
     "editorconfig-checker": "./dist/index.js"
   },
   "publishConfig": {

--- a/src/release.ts
+++ b/src/release.ts
@@ -64,5 +64,5 @@ function getAssetPrefix() {
   } else if (arch === "x64") {
     arch = "amd64"
   }
-  return `ec-${platform}-${arch}`
+  return `editorconfig-checker-${platform}-${arch}`
 }


### PR DESCRIPTION
BREAKING CHANGE: `ec` alias no longer available.

Ref: https://github.com/editorconfig-checker/editorconfig-checker/pull/371
